### PR TITLE
Add haml gem, idea plugin, include subdir docs in example-manual.adoc

### DIFF
--- a/asciidoc-to-deckjs-example/README.adoc
+++ b/asciidoc-to-deckjs-example/README.adoc
@@ -6,6 +6,11 @@ An example project that demonstrates how to convert AsciiDoc to deck.js using th
 
 Convert the AsciiDoc to deck.js by invoking the 'asciidoctor' goal:
 
- $ ./gradlew asciidoctor
+ $ ./gradlew clean asciidoctor
+
+== IntelliJ
+
+If you're using IntelliJ you can generate the IDE's files via:
+ $ ./gradlew idea
 
 Open the file _build/asciidoc/deckjs/example-manual.html_ in your browser to see the generated deckjs file.

--- a/asciidoc-to-deckjs-example/build.gradle
+++ b/asciidoc-to-deckjs-example/build.gradle
@@ -5,11 +5,13 @@ buildscript {
 
 	dependencies {
 		classpath 'org.asciidoctor:asciidoctor-gradle-plugin:1.5.2'
+        classpath 'com.github.jruby-gradle:jruby-gradle-plugin:0.1.5'
 		classpath 'org.ysb33r.gradle:vfs-gradle-plugin:1.0-beta1'
 		classpath 'commons-httpclient:commons-httpclient:3.1'
 	}
 }
 
+apply plugin: 'com.github.jruby-gradle.base'
 apply plugin: 'org.ysb33r.vfs'
 apply plugin: 'java'
 apply plugin: 'org.asciidoctor.convert'
@@ -23,6 +25,15 @@ ext {
 	templateDir = new File(downloadDir,'templates')
 	deckjsDir   = new File(downloadDir,'deck.js')
 }
+
+repositories {
+    jcenter()
+}
+
+dependencies {
+    gems 'rubygems:haml:4.0.6'
+}
+
 task download << {
 	mkdir downloadDir
 	vfs {
@@ -40,6 +51,9 @@ download {
 }
 
 asciidoctor {
+
+    dependsOn jrubyPrepareGems
+
 	sources {
 		include 'example-manual.adoc'
 	}

--- a/asciidoc-to-deckjs-example/src/docs/asciidoc/example-manual.adoc
+++ b/asciidoc-to-deckjs-example/src/docs/asciidoc/example-manual.adoc
@@ -29,6 +29,12 @@ This page was built by the following command:
 
  $ ./gradlew asciidoctor
 
+== Including documents from subdir
+
+.include::subdir/_b.adoc[]
+
+include::subdir/_b.adoc[]
+
 == Images
 
 [.thumb]

--- a/asciidoc-to-deckjs-example/src/docs/asciidoc/subdir/_c.adoc
+++ b/asciidoc-to-deckjs-example/src/docs/asciidoc/subdir/_c.adoc
@@ -1,1 +1,1 @@
-content from _src/docs/asciidoc/subdir/c.adoc_.
+content from _src/docs/asciidoc/subdir/_c.adoc_.

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,13 @@
+apply plugin: 'idea'
+
+idea {
+    project {
+        ipr {
+            withXml { provider ->
+                def node = provider.asNode()
+                //configure git support for the project in idea
+                node.component.find { it.'@name' == 'VcsDirectoryMappings' }?.mapping[0].'@vcs' = 'Git'
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adding haml gem to get rid of this message:

> WARN: tilt autoloading 'tilt/haml' in a non thread-safe way; explicit require 'tilt/haml' suggested.

Adding docs from `subdir` to demonstrate `include` in presentation.